### PR TITLE
Fix for double conversion

### DIFF
--- a/lib/pb.rb
+++ b/lib/pb.rb
@@ -25,6 +25,7 @@ module Pb
     # @return [Google::Protobuf::Timestamp, nil]
     def to_timestamp(t)
       return nil if t.nil?
+      return t if t.is_a?(Google::Protobuf::Timestamp)
       case t
       when DateTime, Date
         t = t.to_time
@@ -40,6 +41,7 @@ module Pb
     # @return [Google::Protobuf::StringValue, nil]
     def to_strval(str)
       return nil if str.nil?
+      return str if str.is_a?(Google::Protobuf::StringValue)
       Google::Protobuf::StringValue.new(value: str)
     end
 
@@ -47,6 +49,7 @@ module Pb
     # @return [Google::Protobuf::Int32Value, nil]
     def to_int32val(num)
       return nil if num.nil?
+      return num if num.is_a?(Google::Protobuf::Int32Value)
       Google::Protobuf::Int32Value.new(value: num)
     end
 
@@ -54,6 +57,7 @@ module Pb
     # @return [Google::Protobuf::Int64Value, nil]
     def to_int64val(num)
       return nil if num.nil?
+      return num if num.is_a?(Google::Protobuf::Int64Value)
       case num
       when String
         n = num.to_i
@@ -67,6 +71,7 @@ module Pb
     # @return [Google::Protobuf::UInt32Value, nil]
     def to_uint32val(num)
       return nil if num.nil?
+      return num if num.is_a?(Google::Protobuf::UInt32Value)
       Google::Protobuf::UInt32Value.new(value: num)
     end
 
@@ -74,6 +79,7 @@ module Pb
     # @return [Google::Protobuf::UInt64Value, nil]
     def to_uint64val(num)
       return nil if num.nil?
+      return num if num.is_a?(Google::Protobuf::UInt64Value)
       case num
       when String
         n = num.to_i
@@ -87,6 +93,7 @@ module Pb
     # @return [Google::Protobuf::FloatValue, nil]
     def to_floatval(num)
       return nil if num.nil?
+      return num if num.is_a?(Google::Protobuf::FloatValue)
       Google::Protobuf::FloatValue.new(value: num)
     end
 
@@ -94,6 +101,7 @@ module Pb
     # @return [Google::Protobuf::DoubleValue, nil]
     def to_doubleval(num)
       return nil if num.nil?
+      return num if num.is_a?(Google::Protobuf::DoubleValue)
       Google::Protobuf::DoubleValue.new(value: num)
     end
 
@@ -101,6 +109,7 @@ module Pb
     # @return [Google::Protobuf::BoolValue, nil]
     def to_boolval(b)
       return nil if b.nil?
+      return b if b.is_a?(Google::Protobuf::BoolValue)
       Google::Protobuf::BoolValue.new(value: b)
     end
 
@@ -108,6 +117,7 @@ module Pb
     # @return [Google::Protobuf::BytesValue, nil]
     def to_bytesval(bytes)
       return nil if bytes.nil?
+      return bytes if bytes.is_a?(Google::Protobuf::BytesValue)
       Google::Protobuf::BytesValue.new(value: bytes)
     end
 

--- a/spec/pb_spec.rb
+++ b/spec/pb_spec.rb
@@ -130,6 +130,98 @@ RSpec.describe Pb do
       end
     end
 
+    context "when value is an instance of a builtin type" do
+      context "when klass is Timestamp" do
+        let(:klass) { Google::Protobuf::Timestamp }
+        let(:value) { klass.new(seconds: 1) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is StringValue" do
+        let(:klass) { Google::Protobuf::StringValue }
+        let(:value) { klass.new(value: "string") }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is Int32Value" do
+        let(:klass) { Google::Protobuf::Int32Value }
+        let(:value) { klass.new(value: 1) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is Int64Value" do
+        let(:klass) { Google::Protobuf::Int64Value }
+        let(:value) { klass.new(value: 1) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is UInt32Value" do
+        let(:klass) { Google::Protobuf::UInt32Value }
+        let(:value) { klass.new(value: 1) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is UInt64Value" do
+        let(:klass) { Google::Protobuf::UInt64Value }
+        let(:value) { klass.new(value: 1) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is FloatValue" do
+        let(:klass) { Google::Protobuf::FloatValue }
+        let(:value) { klass.new(value: 1.0) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is DoubleValue" do
+        let(:klass) { Google::Protobuf::DoubleValue }
+        let(:value) { klass.new(value: 1.0) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is BoolValue" do
+        let(:klass) { Google::Protobuf::BoolValue }
+        let(:value) { klass.new(value: true) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+
+      context "when klass is BytesValue" do
+        let(:klass) { Google::Protobuf::BytesValue }
+        let(:value) { klass.new(value: "\x0\x1".encode(Encoding::ASCII_8BIT)) }
+
+        it "returns protobuf object" do
+          expect(Pb.to_proto(klass, value)).to eq value
+        end
+      end
+    end
+
     context "when value is not builtin type" do
       let(:proto_class_a) {
         klass_b = proto_class_b  # Assign to variable


### PR DESCRIPTION
## Why

Sometimes, we want to pass values of type builtin types such as `Google::Protobuf::StringValue` to `Pb.to_proto`. (e.g. construct a protobuf object using responses from other gRPC services.)
In the current version, it will cause a runtime error due to double conversion as follows:

```
[1] pry(main)> x = Google::Protobuf::StringValue.new(value: "string")
=> <Google::Protobuf::StringValue: value: "string">
[2] pry(main)> Pb.to_proto(Google::Protobuf::StringValue, x)
Google::Protobuf::TypeError: Invalid argument for string field 'value' (given Google::Protobuf::StringValue).
from /Users/agatan/.anyenv/envs/rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/the_pb-0.0.1/lib/pb.rb:43:in `initialize'
[3] pry(main)> Pb.to_proto(Google::Protobuf::StringValue, x.value)
=> <Google::Protobuf::StringValue: value: "string">
```

## What

When the value is already protobuf compatible, `Pb` should do nothing and just return the given value.